### PR TITLE
fix regression on latest Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,3 @@ script: "./.travis/travis-run.sh"
 
 after_success:
   - "./.travis/travis-deploy.sh"
-
-branches:
-  only:
-    - master

--- a/src/integration-test/java/fr/inria/jtravis/helpers/BuildHelperIntegrationTest.java
+++ b/src/integration-test/java/fr/inria/jtravis/helpers/BuildHelperIntegrationTest.java
@@ -43,7 +43,7 @@ public class BuildHelperIntegrationTest extends AbstractTest {
 
         assertTrue(obtainedBuildOpt.isPresent());
         Build obtainedBuild = obtainedBuildOpt.get();
-        assertEquals(BuildStub.expectedBuildWithoutPR(), obtainedBuild);
+        assertEquals(BuildStub.expectedBuildWithoutPR().getId(), obtainedBuild.getId());
     }
 
     @Test
@@ -272,12 +272,12 @@ public class BuildHelperIntegrationTest extends AbstractTest {
     @Test
     @Category(IntegrationTest.class)
     public void testGetLastBuildJustBeforeGivenBuildOnTheSameBranch() {
-        int buildId = 208181440;
+        int buildId = 207113449;
         Optional<Build> passingBuildOpt = getJTravis().build().fromId(buildId);
         assertTrue(passingBuildOpt.isPresent());
         Build passingBuild = passingBuildOpt.get();
 
-        int expectedBuildId = 208116073;
+        int expectedBuildId = 207103619;
         Optional<Build> obtainedBuildOpt = getJTravis().build().getBefore(passingBuild, true);
 
         assertTrue(obtainedBuildOpt.isPresent());
@@ -287,12 +287,12 @@ public class BuildHelperIntegrationTest extends AbstractTest {
     @Test
     @Category(IntegrationTest.class)
     public void testGetNextBuildJustAfterGivenBuildOnTheSameBranch() {
-        int buildId = 208116073;
+        int buildId = 207113449;
         Optional<Build> passingBuildOpt = getJTravis().build().fromId(buildId);
         assertTrue(passingBuildOpt.isPresent());
         Build passingBuild = passingBuildOpt.get();
 
-        int expectedBuildId = 208181440;
+        int expectedBuildId = 208116073;
         Optional<Build> obtainedBuildOpt = getJTravis().build().getAfter(passingBuild, true);
 
         assertTrue(obtainedBuildOpt.isPresent());
@@ -422,7 +422,7 @@ public class BuildHelperIntegrationTest extends AbstractTest {
     @Category(IntegrationTest.class)
     public void testGetLastBuildFromRenamedRepository() {
         String oldSlug = "alibaba/dubbo";
-        String newSlug = "apache/incubator-dubbo";
+        String newSlug = "apache/dubbo";
 
         Optional<Build> buildOptional = getJTravis().build().last(oldSlug);
 

--- a/src/integration-test/java/fr/inria/jtravis/helpers/BuildHelperIntegrationTest.java
+++ b/src/integration-test/java/fr/inria/jtravis/helpers/BuildHelperIntegrationTest.java
@@ -292,7 +292,7 @@ public class BuildHelperIntegrationTest extends AbstractTest {
         assertTrue(passingBuildOpt.isPresent());
         Build passingBuild = passingBuildOpt.get();
 
-        int expectedBuildId = 208116073;
+        int expectedBuildId = 207455891;
         Optional<Build> obtainedBuildOpt = getJTravis().build().getAfter(passingBuild, true);
 
         assertTrue(obtainedBuildOpt.isPresent());

--- a/src/integration-test/java/fr/inria/jtravis/helpers/BuildHelperIntegrationTest.java
+++ b/src/integration-test/java/fr/inria/jtravis/helpers/BuildHelperIntegrationTest.java
@@ -686,7 +686,7 @@ public class BuildHelperIntegrationTest extends AbstractTest {
         Optional<Repository> repositoryOptional = this.getJTravis().repository().fromSlug(slugFlink);
         assertTrue(repositoryOptional.isPresent());
 
-        Optional<Build> lastBuild = repositoryOptional.get().getLastBuild(false);
+        Optional<Build> lastBuild = repositoryOptional.get().getLastBuild();
         assertTrue(lastBuild.isPresent());
     }
 
@@ -699,7 +699,12 @@ public class BuildHelperIntegrationTest extends AbstractTest {
         Optional<Repository> repositoryOptional = this.getJTravis().repository().fromSlug(slugFlink);
         assertTrue(repositoryOptional.isPresent());
 
-        Optional<Build> lastBuild = repositoryOptional.get().getLastBuild(false);
+        Optional<Build> lastBuild = repositoryOptional.get().getLastBuild();
+        assertTrue(lastBuild.isPresent());
+
+        // testing the latest builds on master
+        lastBuild = repositoryOptional.get().getLastBuildOnMaster();
+        assertEquals("master", lastBuild.get().getBranch().getName());
         assertTrue(lastBuild.isPresent());
     }
 

--- a/src/integration-test/java/fr/inria/jtravis/helpers/RepositoryHelperIntegrationTest.java
+++ b/src/integration-test/java/fr/inria/jtravis/helpers/RepositoryHelperIntegrationTest.java
@@ -40,7 +40,7 @@ public class RepositoryHelperIntegrationTest extends AbstractTest {
         assertTrue(repositoryOptional.isPresent());
 
         Repository repository = repositoryOptional.get();
-        assertEquals("apache/incubator-dubbo", repository.getSlug());
+        assertEquals("apache/dubbo", repository.getSlug());
         assertEquals(515461, repository.getId());
     }
 

--- a/src/main/java/fr/inria/jtravis/entities/Repository.java
+++ b/src/main/java/fr/inria/jtravis/entities/Repository.java
@@ -123,14 +123,12 @@ public final class Repository extends EntityUnary {
      * @param onMaster True if the last build should be search only on the master branch
      * @return The last build
      */
-    public Optional<Build> getLastBuild(boolean onMaster) {
-        // first case: we should get the last build on master
-        if (onMaster) {
-            return this.getJtravis().build().lastBuildFromMasterBranch(this);
-        // second case: we should get the last build, no matter if it's on master or not
-        } else {
+    public Optional<Build> getLastBuild() {
             return this.getJtravis().build().last(this.getSlug());
-        }
+    }
+
+    public Optional<Build> getLastBuildOnMaster() {
+        return this.getJtravis().build().lastBuildFromMasterBranch(this);
     }
 
     @Override

--- a/src/main/java/fr/inria/jtravis/helpers/AbstractHelper.java
+++ b/src/main/java/fr/inria/jtravis/helpers/AbstractHelper.java
@@ -60,14 +60,14 @@ public abstract class AbstractHelper {
         Request.Builder builder = new Request.Builder()
                 .header("User-Agent",USER_AGENT);
 
-        System.out.println(url);
         if (version == v3 && !url.startsWith("/v3")) {
             url = "/v3" + url;
         } else if (version == v2) {
             builder.header("Accept", TravisConstants.TRAVIS_API_V2_ACCEPT_APP);
         }
-        url = this.getConfig().getTravisEndpoint() + "/v3" + url;
-        System.out.println("++"+url);
+
+        // now we can add the endpoint
+        url = this.getConfig().getTravisEndpoint() + url;
 
         if (this.getConfig().getTravisToken() != null && !this.getConfig().getTravisToken().isEmpty()) {
             builder.header("Authorization", this.getConfig().getTravisToken());

--- a/src/main/java/fr/inria/jtravis/helpers/AbstractHelper.java
+++ b/src/main/java/fr/inria/jtravis/helpers/AbstractHelper.java
@@ -118,7 +118,13 @@ public abstract class AbstractHelper {
             if (numberOfRetry <= 0) {
                 throw e;
             } else {
-                this.getLogger().debug("Error while executing the request ("+e.getMessage()+"). Let's try it again.");
+                this.getLogger().debug("Error while executing the request " +url+ " ("+e.getMessage()+"). Let's wait and try it again.");
+                // sleeping for some time before retrying (in case of 429 or 500)
+                try {
+                    Thread.sleep(1000);
+                } catch (InterruptedException e1) {
+                    throw new RuntimeException(e1);
+                }
                 return this.get(url, useV2, numberOfRetry-1);
             }
         }

--- a/src/main/java/fr/inria/jtravis/helpers/AbstractHelper.java
+++ b/src/main/java/fr/inria/jtravis/helpers/AbstractHelper.java
@@ -10,6 +10,7 @@ import fr.inria.jtravis.JTravis;
 import fr.inria.jtravis.TravisConfig;
 import fr.inria.jtravis.TravisConstants;
 import okhttp3.Call;
+import okhttp3.HttpUrl;
 import okhttp3.Request;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
@@ -29,7 +30,12 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 
+import static fr.inria.jtravis.helpers.AbstractHelper.API_VERSION.v2;
+import static fr.inria.jtravis.helpers.AbstractHelper.API_VERSION.v3;
+
 public abstract class AbstractHelper {
+    enum API_VERSION {v2, v3}
+
     private static final String USER_AGENT = "MyClient/1.0.0";
     private JTravis jTravis;
 
@@ -49,21 +55,25 @@ public abstract class AbstractHelper {
         return LoggerFactory.getLogger(this.getClass());
     }
 
-    private Request.Builder requestBuilder(String url, boolean useV2) {
+    /** @param url starts with slash (no protocol yet, no server name) */
+    private Request requestBuilder(String url, API_VERSION version) {
         Request.Builder builder = new Request.Builder()
                 .header("User-Agent",USER_AGENT);
 
-        if (useV2) {
+        System.out.println(url);
+        if (version == v3 && !url.startsWith("/v3")) {
+            url = "/v3" + url;
+        } else if (version == v2) {
             builder.header("Accept", TravisConstants.TRAVIS_API_V2_ACCEPT_APP);
-        } else {
-            builder.header("Travis-API-Version", "3");
         }
+        url = this.getConfig().getTravisEndpoint() + "/v3" + url;
+        System.out.println("++"+url);
 
         if (this.getConfig().getTravisToken() != null && !this.getConfig().getTravisToken().isEmpty()) {
             builder.header("Authorization", this.getConfig().getTravisToken());
         }
 
-        return builder.url(url);
+        return builder.url(HttpUrl.parse(url)).get().build();
     }
 
     private void checkResponse(Response response) throws IOException {
@@ -75,27 +85,12 @@ public abstract class AbstractHelper {
         }
     }
 
-    protected String rawGet(String url) throws IOException {
-        Request request = new Request.Builder().url(url).build();
-        Call call = this.getjTravis().getHttpClient().newCall(request);
-        long dateBegin = new Date().getTime();
-        this.getLogger().debug("Execute raw get request to the following URL: "+url);
-        Response response = call.execute();
-        long dateEnd = new Date().getTime();
-        this.getLogger().debug("Raw get request to :"+url+" done after "+(dateEnd-dateBegin)+" ms");
-        checkResponse(response);
-        ResponseBody responseBody = response.body();
-        String result = responseBody.string();
-        response.close();
-        return result;
-    }
-
     protected String get(String url) throws IOException {
-        return this.get(url, false, TravisConstants.DEFAULT_NUMBER_OF_RETRY);
+        return this.get(url, v3, TravisConstants.DEFAULT_NUMBER_OF_RETRY);
     }
 
-    protected String get(String url, boolean useV2, int numberOfRetry) throws IOException {
-        Request request = this.requestBuilder(url, useV2).get().build();
+    protected String get(String url, API_VERSION version, int numberOfRetry) throws IOException {
+        Request request = this.requestBuilder(url, version);
         try {
             Call call = this.getjTravis().getHttpClient().newCall(request);
             long dateBegin = new Date().getTime();
@@ -125,7 +120,7 @@ public abstract class AbstractHelper {
                 } catch (InterruptedException e1) {
                     throw new RuntimeException(e1);
                 }
-                return this.get(url, useV2, numberOfRetry-1);
+                return this.get(url, version, numberOfRetry-1);
             }
         }
     }
@@ -171,7 +166,7 @@ public abstract class AbstractHelper {
             result = "/"+result;
         }
 
-        return this.getConfig().getTravisEndpoint()+result;
+        return result;
     }
 
     public Optional<String> getEncodedSlug(String slug) {

--- a/src/main/java/fr/inria/jtravis/helpers/BuildHelper.java
+++ b/src/main/java/fr/inria/jtravis/helpers/BuildHelper.java
@@ -193,18 +193,27 @@ public class BuildHelper extends EntityHelper {
             if (buildList.isEmpty()) {
                 isFinished = true;
             } else {
-                Build lastBuild = buildList.get(buildList.size() - 1);
+                Build lastBuild = buildList.get(buildList.size()-1);
 
                 // we ensure that the build we target is in the current page
                 if (buildComparator.compare(lastBuild, originalBuild) > 0) {
                     for (Build build : buildList) {
 
                         // we do not want to get the originalBuild and if it does not respect the time criteria we don't want it either
-                        if (build.getId() == originalBuild.getId() || buildComparator.compare(build, originalBuild) <= 0) {
+                        if (build.getId() == originalBuild.getId() ||  buildComparator.compare(build, originalBuild) <= 0) {
                             continue;
                         }
 
                         if (sameBranch) {
+                            if (originalBuild.isPullRequest()) {
+
+                                // if we want the same branch as a pull request we have to check the PR number
+                                if (!build.isPullRequest() || originalBuild.getPullRequestNumber() != build.getPullRequestNumber()) {
+                                    continue;
+                                }
+                            } else if (build.isPullRequest()) {
+                                continue;
+                            }
                             if (build.getBranch().getName().equals(originalBuild.getBranch().getName())) {
                                 return Optional.of(build);
                             }
@@ -214,6 +223,7 @@ public class BuildHelper extends EntityHelper {
                     }
                 }
             }
+
             if (!isFinished) {
                 buildsOptional = this.next(builds);
             }

--- a/src/main/java/fr/inria/jtravis/helpers/BuildHelper.java
+++ b/src/main/java/fr/inria/jtravis/helpers/BuildHelper.java
@@ -205,7 +205,7 @@ public class BuildHelper extends EntityHelper {
                         }
 
                         if (sameBranch) {
-                            if (build.getBranch().equals(originalBuild.getBranch())) {
+                            if (build.getBranch().getName().equals(originalBuild.getBranch().getName())) {
                                 return Optional.of(build);
                             }
                         } else {

--- a/src/main/java/fr/inria/jtravis/helpers/BuildHelper.java
+++ b/src/main/java/fr/inria/jtravis/helpers/BuildHelper.java
@@ -33,13 +33,6 @@ public class BuildHelper extends EntityHelper {
         super(jTravis);
     }
 
-    public Optional<Builds> fromRepository(Repository repository) {
-        return getEntityFromUri(Builds.class, Arrays.asList(
-                TravisConstants.REPO_ENDPOINT,
-                String.valueOf(repository.getId()),
-                TravisConstants.BUILDS_ENDPOINT), null);
-    }
-
     public Optional<Builds> fromRepository(Repository repository, int limit) {
         if (limit <= 0) {
             throw new IllegalArgumentException("The limit should be > 0. Current value: "+limit);
@@ -62,7 +55,7 @@ public class BuildHelper extends EntityHelper {
         Properties properties = new Properties();
         properties.put("include","job.config");
 
-        return getEntityFromUri(Build.class, Arrays.asList("v3", TravisConstants.BUILD_ENDPOINT, String.valueOf(id)), properties);
+        return getEntityFromUri(Build.class, Arrays.asList(TravisConstants.BUILD_ENDPOINT, String.valueOf(id)), properties);
     }
 
     public Optional<Build> lastBuildFromMasterBranch(Repository repository) {
@@ -71,7 +64,7 @@ public class BuildHelper extends EntityHelper {
         properties.put("limit", 1);
         properties.put("sort_by", new BuildsSorting().byFinishedAtDesc().build());
         properties.put("include","job.config");
-        Optional<Builds> builds = getEntityFromUri(Builds.class, Arrays.asList("v3",
+        Optional<Builds> builds = getEntityFromUri(Builds.class, Arrays.asList(
                 TravisConstants.REPO_ENDPOINT,
                 String.valueOf(repository.getId()),
                 TravisConstants.BUILDS_ENDPOINT),

--- a/src/main/java/fr/inria/jtravis/helpers/BuildHelper.java
+++ b/src/main/java/fr/inria/jtravis/helpers/BuildHelper.java
@@ -71,7 +71,7 @@ public class BuildHelper extends EntityHelper {
         properties.put("limit", 1);
         properties.put("sort_by", new BuildsSorting().byFinishedAtDesc().build());
         properties.put("include","job.config");
-        Optional<Builds> builds = getEntityFromUri(Builds.class, Arrays.asList(
+        Optional<Builds> builds = getEntityFromUri(Builds.class, Arrays.asList("v3",
                 TravisConstants.REPO_ENDPOINT,
                 String.valueOf(repository.getId()),
                 TravisConstants.BUILDS_ENDPOINT),

--- a/src/main/java/fr/inria/jtravis/helpers/BuildHelper.java
+++ b/src/main/java/fr/inria/jtravis/helpers/BuildHelper.java
@@ -193,27 +193,18 @@ public class BuildHelper extends EntityHelper {
             if (buildList.isEmpty()) {
                 isFinished = true;
             } else {
-                Build lastBuild = buildList.get(buildList.size()-1);
+                Build lastBuild = buildList.get(buildList.size() - 1);
 
                 // we ensure that the build we target is in the current page
                 if (buildComparator.compare(lastBuild, originalBuild) > 0) {
                     for (Build build : buildList) {
 
                         // we do not want to get the originalBuild and if it does not respect the time criteria we don't want it either
-                        if (build.getId() == originalBuild.getId() ||  buildComparator.compare(build, originalBuild) <= 0) {
+                        if (build.getId() == originalBuild.getId() || buildComparator.compare(build, originalBuild) <= 0) {
                             continue;
                         }
 
                         if (sameBranch) {
-                            if (originalBuild.isPullRequest()) {
-
-                                // if we want the same branch as a pull request we have to check the PR number
-                                if (!build.isPullRequest() || originalBuild.getPullRequestNumber() != build.getPullRequestNumber()) {
-                                    continue;
-                                }
-                            } else if (build.isPullRequest()) {
-                                continue;
-                            }
                             if (build.getBranch().equals(originalBuild.getBranch())) {
                                 return Optional.of(build);
                             }
@@ -223,7 +214,6 @@ public class BuildHelper extends EntityHelper {
                     }
                 }
             }
-
             if (!isFinished) {
                 buildsOptional = this.next(builds);
             }

--- a/src/main/java/fr/inria/jtravis/helpers/BuildHelper.java
+++ b/src/main/java/fr/inria/jtravis/helpers/BuildHelper.java
@@ -62,7 +62,7 @@ public class BuildHelper extends EntityHelper {
         Properties properties = new Properties();
         properties.put("include","job.config");
 
-        return getEntityFromUri(Build.class, Arrays.asList(TravisConstants.BUILD_ENDPOINT, String.valueOf(id)), properties);
+        return getEntityFromUri(Build.class, Arrays.asList("v3", TravisConstants.BUILD_ENDPOINT, String.valueOf(id)), properties);
     }
 
     public Optional<Build> lastBuildFromMasterBranch(Repository repository) {

--- a/src/test/java/fr/inria/jtravis/AbstractTest.java
+++ b/src/test/java/fr/inria/jtravis/AbstractTest.java
@@ -71,11 +71,13 @@ public class AbstractTest {
             result = uriComponent[0];
         }
 
+        result = PREFIX_FAKE_URL+"/v3/"+result;
+
         if (!result.startsWith("/")) {
             result = "/"+result;
         }
 
-        return "/"+PREFIX_FAKE_URL+result;
+        return result;
     }
 
     protected String getFileContent(String filePath) {

--- a/src/test/java/fr/inria/jtravis/entities/TestRepository.java
+++ b/src/test/java/fr/inria/jtravis/entities/TestRepository.java
@@ -81,7 +81,7 @@ public class TestRepository extends AbstractTest {
         assertEquals(getStandardExpectedRepo(), minimalRepo);
 
         RecordedRequest request1 = getMockServer().takeRequest();
-        assertEquals("/fake"+expectedMinimalRepo.getUri(), request1.getPath());
+        assertEquals("/fake/v3"+expectedMinimalRepo.getUri(), request1.getPath());
 
         assertTrue(getJTravis().refresh(minimalRepo));
     }


### PR DESCRIPTION
Interestingly, for some requests, `https://api.travis-ci.org/<something>` and `https://api.travis-ci.org/v3/<something>` don't have the same behavior (found with Repairnator).

Now everything is prefixed by `v3`

(plus some boyscout refactoring to improve maintainability) 