### PR TITLE
Fix jenkins maven repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,13 @@
         <maven-coveralls-plugin.version>4.0.0</maven-coveralls-plugin.version>
     </properties>
 
+    <repositories>
+        <repository>
+            <id>repo.jenkins-ci.org</id>
+            <url>https://repo.jenkins-ci.org/public/</url>
+        </repository>
+    </repositories>
+
     <dependencies>
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>


### PR DESCRIPTION
Right now there is an error resulting from one of the transitive dependencies of `jtravis`:

> [ERROR] Failed to execute goal on project repairnator-core: Could not resolve dependencies for project fr.inria.repairnator:repairnator-core:jar:3.3-SNAPSHOT: Failed to collect dependencies at fr.inria.jtravis:jtravis:jar:2.6 -> org.kohsuke:github-api:jar:1.90 -> com.infradna.tool:bridge-method-annotation:jar:1.17 -> org.jenkins-ci:annotation-indexer:jar:1.4: Failed to read artifact descriptor for org.jenkins-ci:annotation-indexer:jar:1.4: Could not transfer artifact org.jenkins-ci:jenkins:pom:1.26 from/to maven-default-http-blocker (http://0.0.0.0/): Blocked mirror for repositories: [repo.jenkins-ci.org (http://repo.jenkins-ci.org/public/, default, releases+snapshots)] -> [Help 1]

It results in `repairnator-core` not building, as well as its dependents. This PR fixes it.

I avoided bumping the version because the test suite is out-of-date due to the move from `travis-ci.org` to `travis-ci.com`, so that no changes to the code running are made. 

Still, I have a [branch](https://github.com/andre15silva/jtravis/tree/bump-github-api) with that, were I bumped the dependency from 1.90 to 1.92 where the issue is fixed. Bumping instead of adding the repo to our pom results in an additional failing test case.

Note that if we bump any higher we get errors due to API changes in the problematic dependency.