### PR TITLE
Move default endpoint to travis-ci.com

### DIFF
--- a/src/main/java/fr/inria/jtravis/TravisConstants.java
+++ b/src/main/java/fr/inria/jtravis/TravisConstants.java
@@ -3,7 +3,7 @@ package fr.inria.jtravis;
 public class TravisConstants {
     public static final String TRAVIS_API_V2_ACCEPT_APP = "application/vnd.travis-ci.2+json";
 
-    public static final String TRAVIS_API_ENDPOINT="https://api.travis-ci.org";
+    public static final String TRAVIS_API_ENDPOINT="https://api.travis-ci.com";
     public static final String TRAVIS_COMMERCIAL_API_ENDPOINT="https://api.travis-ci.com";
 
     public static final String TRAVIS_TOKEN_ENV_PROPERTY = "TRAVIS_TOKEN";


### PR DESCRIPTION
> Since June 15th, 2021, the building on travis-ci.org is ceased. Please use travis-ci.com from now on.

Information from https://travis-ci.org/. Date of access: 15/06/2021.

Since https://travis-ci.org/ has ceased, we should move the default to https://travis-ci.com/